### PR TITLE
feat(where-to-buy): add scroll shadow to dealer list

### DIFF
--- a/storefront/components/ui/scroll-shadow.tsx
+++ b/storefront/components/ui/scroll-shadow.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useEffect, useRef, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface ScrollShadowProps {
+  children: ReactNode;
+  className?: string;
+  shadowClassName?: string;
+  maxHeight?: string;
+}
+
+export default function ScrollShadow({
+  children,
+  className,
+  shadowClassName,
+  maxHeight = "560px",
+}: ScrollShadowProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [showShadow, setShowShadow] = useState(false);
+  const [isScrollable, setIsScrollable] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const checkScroll = () => {
+      const scrollable = container.scrollHeight > container.clientHeight;
+      setIsScrollable(scrollable);
+      
+      if (scrollable) {
+        const isAtBottom = 
+          container.scrollHeight - container.scrollTop - container.clientHeight < 2;
+        setShowShadow(!isAtBottom);
+      } else {
+        setShowShadow(false);
+      }
+    };
+
+    // Initial check
+    checkScroll();
+
+    // Listen for scroll events
+    container.addEventListener("scroll", checkScroll, { passive: true });
+    
+    // Also check on resize
+    window.addEventListener("resize", checkScroll);
+
+    return () => {
+      container.removeEventListener("scroll", checkScroll);
+      window.removeEventListener("resize", checkScroll);
+    };
+  }, [children]);
+
+  return (
+    <div className="relative">
+      <div
+        ref={containerRef}
+        className={cn("overflow-y-auto", className)}
+        style={{ maxHeight }}
+      >
+        {children}
+      </div>
+      
+      {/* Bottom shadow overlay - only shown when scrollable and not at bottom */}
+      <div
+        className={cn(
+          "pointer-events-none absolute bottom-0 left-0 right-0 h-12",
+          "bg-gradient-to-t from-background to-transparent",
+          "transition-opacity duration-200",
+          showShadow ? "opacity-100" : "opacity-0",
+          shadowClassName
+        )}
+        aria-hidden="true"
+      />
+    </div>
+  );
+}

--- a/storefront/components/where-to-buy/where-to-buy-content.tsx
+++ b/storefront/components/where-to-buy/where-to-buy-content.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import Wrapper from "@/components/wrapper";
 import Container from "@/components/container";
+import ScrollShadow from "@/components/ui/scroll-shadow";
 import DealerList from "./dealer-list";
 import { DEALERS } from "@/constants/dealers";
 import type { DealerCategory } from "@/types/dealers";
@@ -105,14 +106,14 @@ export default function WhereToBuyContent() {
             />
           </div>
 
-          {/* List */}
-          <div className="order-2 lg:order-1 lg:max-h-[560px] lg:overflow-y-auto">
+          {/* List with scroll shadow */}
+          <ScrollShadow className="order-2 lg:order-1" maxHeight="560px">
             <DealerList
               dealers={filteredDealers}
               selectedDealerId={selectedDealerId}
               onSelectDealer={setSelectedDealerId}
             />
-          </div>
+          </ScrollShadow>
         </div>
       </Container>
     </Wrapper>


### PR DESCRIPTION
Adds a bottom gradient shadow to the dealer list to indicate scrollability. The shadow automatically hides when scrolled to the bottom. Uses existing theme colors for consistency.

AI-generated code (Claude Code). Closes #5