### PR TITLE
feat: add sitemap.xml and robots.txt with locale support

### DIFF
--- a/storefront/app/robots.ts
+++ b/storefront/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: '/api/',
+      },
+    ],
+    sitemap: 'https://sgtools.rs/sitemap.xml',
+  };
+}

--- a/storefront/app/sitemap.ts
+++ b/storefront/app/sitemap.ts
@@ -1,0 +1,49 @@
+import { MetadataRoute } from 'next';
+
+const baseUrl = 'https://sgtools.rs';
+const locales = ['en', 'sr'] as const;
+
+type Page = {
+  path: string;
+  changeFrequency: 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+  priority: number;
+};
+
+const pages: Page[] = [
+  { path: '', changeFrequency: 'weekly', priority: 1.0 },
+  { path: '/about', changeFrequency: 'monthly', priority: 0.8 },
+  { path: '/faq', changeFrequency: 'monthly', priority: 0.7 },
+  { path: '/contact', changeFrequency: 'monthly', priority: 0.6 },
+  { path: '/where-to-buy', changeFrequency: 'weekly', priority: 0.9 },
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = [];
+  const now = new Date();
+
+  for (const page of pages) {
+    for (const locale of locales) {
+      const url = `${baseUrl}/${locale}${page.path}`;
+      
+      const alternates: { languages: Record<string, string> } = {
+        languages: {},
+      };
+      
+      for (const altLocale of locales) {
+        if (altLocale !== locale) {
+          alternates.languages[altLocale] = `${baseUrl}/${altLocale}${page.path}`;
+        }
+      }
+
+      entries.push({
+        url,
+        lastModified: now,
+        changeFrequency: page.changeFrequency,
+        priority: page.priority,
+        alternates,
+      });
+    }
+  }
+
+  return entries;
+}


### PR DESCRIPTION
## Summary

Implements sitemap.xml and robots.txt following Next.js App Router conventions and SEO best practices.

## Changes

### robots.txt (app/robots.ts)
- Uses Next.js Metadata API
- Allows all crawlers for public pages
- Disallows /api/ routes
- References sitemap URL

### sitemap.xml (app/sitemap.ts)
- Generates entries dynamically for all locales (en, sr)
- Includes all public pages: home, about, FAQ, contact, where-to-buy
- Sets appropriate changeFrequency and priority per page type
- Adds hreflang alternates for each locale variant
- Sets lastModified dates

## Testing

After deployment:
- Verify https://sgtools.rs/robots.txt returns valid robots.txt
- Verify https://sgtools.rs/sitemap.xml returns valid XML sitemap
- Validate with Google Rich Results Test

Closes #13